### PR TITLE
Use async/await in ExecuteTimedTaskWrapper

### DIFF
--- a/src/DNS-BLM.Api/TimedTasks/TimedHostedService.cs
+++ b/src/DNS-BLM.Api/TimedTasks/TimedHostedService.cs
@@ -33,10 +33,10 @@ public abstract class TimedHostedService : IDisposable, IHostedService
     /// Wrapper method for executing a timed task. Logs the start and end of the task execution.
     /// </summary>
     /// <param name="state">An optional parameter that can represent state information used in the task execution.</param>
-    void ExecuteTimedTaskWrapper(object? state = null)
+    async void ExecuteTimedTaskWrapper(object? state = null)
     {
         _logger.LogInformation("Executing Timed Task: " + TaskName);
-        ExecuteTimedTask(state);
+        await ExecuteTimedTask(state);
         _logger.LogInformation("Finished Timed Task: " + TaskName);
     }
 


### PR DESCRIPTION
Refactored the ExecuteTimedTaskWrapper method to use async/await for proper asynchronous execution. This ensures non-blocking behavior and aligns with best practices for handling asynchronous tasks.