### PR TITLE
Add delay before fetching analysis results from VirusTotal

### DIFF
--- a/src/DNS-BLM.Infrastructure/Services/ScannerServices/VirusTotalService.cs
+++ b/src/DNS-BLM.Infrastructure/Services/ScannerServices/VirusTotalService.cs
@@ -49,7 +49,9 @@ public class VirusTotalService : IBlacklistScanner
                 }
 
                 _logger.LogDebug("Received analysis ID {AnalysisId} for domain {Domain}", analysisId, domain);
-
+                
+                await Task.Delay(10000, cancellationToken);
+                
                 var response = await client.GetAsync($"analyses/{analysisId}", cancellationToken);
                 response.EnsureSuccessStatusCode();
                 var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);


### PR DESCRIPTION
Introduce a 10-second delay to ensure the analysis process has time to complete before fetching results. This helps prevent potential issues with prematurely requesting data.